### PR TITLE
Do not require v= parameter

### DIFF
--- a/ytEmbed.user.js
+++ b/ytEmbed.user.js
@@ -10,7 +10,7 @@
 !(function()
 {	//	replace screenshot by embeded YT capture if possible
 	var screenshot = document.querySelector('#screenshot img');
-	var yt = screenshot && document.querySelector('#links a[href*="v="][href*="youtu"]');
+	var yt = screenshot && document.querySelector('#links a[href*="youtu"]');
 	if( yt )
 	{
 		var i=document.createElement('iframe');


### PR DESCRIPTION
YouTube's recommended sharing links are now simple paths, such as https://youtu.be/OjZVSqhReqA

which we can see used on this page: https://www.pouet.net/prod.php?which=86757

I think the simplest solution is to simply relax the requirement for the link to contain a `v=...` parameter.